### PR TITLE
HEROKU_ENVがtrueのときに限定してベーシック認証を付与

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,12 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  before_action :basic if ENV['HEROKU_ENV']
+
+  private
+  def basic
+    authenticate_or_request_with_http_basic do |user, pass|
+      user == ENV['HEROKU_BASIC_USER'] && pass == ENV['HEROKU_BASIC_PASS']
+    end
+  end
 end


### PR DESCRIPTION
Fix #6 